### PR TITLE
cleanup kernels

### DIFF
--- a/src/masonite/foundation/CoreKernel.py
+++ b/src/masonite/foundation/CoreKernel.py
@@ -1,4 +1,3 @@
-import os
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -8,43 +7,40 @@ if TYPE_CHECKING:
 class CoreKernel:
     def __init__(self, app: "Application"):
         self.application = app
-        self.register_core()
+        self._register_core()
 
-    def register_core(self) -> None:
+    def register(self) -> None:
+        pass
+
+    def _register_core(self) -> None:
         """Register core Masonite features in the project."""
-        self.load_environment()
-        self.register_framework()
-        self.register_command_capsule()
+        self._register_framework()
+        self._register_capsules()
 
-    def load_environment(self) -> None:
-        """Load environment variables into the application."""
-        from ..environment import LoadEnvironment
-        LoadEnvironment()
-
-    def register_framework(self) -> None:
-        """Register Core Fraamework requirements"""
+    def _register_framework(self) -> None:
+        """Register Core Framework requirements"""
+        import os
         from .response_handler import response_handler
-        from ..middleware import MiddlewareCapsule
-        from ..routes import Router
-        from ..loader import Loader
+        from ..environment import LoadEnvironment
 
+        LoadEnvironment()
         self.application.set_response_handler(response_handler)
         self.application.use_storage_path(
             os.path.join(self.application.base_path, "storage")
         )
-        self.application.bind("middleware", MiddlewareCapsule())
-        self.application.bind(
-            "router",
-            Router(),
-        )
-        self.application.bind("loader", Loader())
 
-    def register_command_capsule(self) -> None:
-        """Register the 'commands' binding in the application."""
+    def _register_capsules(self) -> None:
+        """Register the minimum required capsules."""
         from cleo import Application as CommandApplication
-        from ..commands import CommandCapsule
         from .. import __version__
+        from ..commands.CommandCapsule import CommandCapsule
+        from ..middleware import MiddlewareCapsule
+        from ..loader import Loader
+        from ..routes import Router
 
+        self.application.bind("middleware", MiddlewareCapsule())
+        self.application.bind("loader", Loader())
+        self.application.bind("router", Router())
         self.application.bind(
             "commands",
             CommandCapsule(CommandApplication("Masonite", __version__))

--- a/src/masonite/foundation/CoreKernel.py
+++ b/src/masonite/foundation/CoreKernel.py
@@ -8,8 +8,9 @@ if TYPE_CHECKING:
 class CoreKernel:
     def __init__(self, app: "Application"):
         self.application = app
+        self.register_core()
 
-    def register(self) -> None:
+    def register_core(self) -> None:
         """Register core Masonite features in the project."""
         self.load_environment()
         self.register_framework()

--- a/src/masonite/foundation/CoreKernel.py
+++ b/src/masonite/foundation/CoreKernel.py
@@ -20,7 +20,7 @@ class CoreKernel:
     def _register_framework(self) -> None:
         """Register Core Framework requirements"""
         import os
-        from .response_handler import response_handler
+        from . import response_handler
         from ..environment import LoadEnvironment
 
         LoadEnvironment()

--- a/src/masonite/foundation/CoreKernel.py
+++ b/src/masonite/foundation/CoreKernel.py
@@ -1,0 +1,50 @@
+import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .Application import Application
+
+
+class CoreKernel:
+    def __init__(self, app: "Application"):
+        self.application = app
+
+    def register(self) -> None:
+        """Register core Masonite features in the project."""
+        self.load_environment()
+        self.register_framework()
+        self.register_command_capsule()
+
+    def load_environment(self) -> None:
+        """Load environment variables into the application."""
+        from ..environment import LoadEnvironment
+        LoadEnvironment()
+
+    def register_framework(self) -> None:
+        """Register Core Fraamework requirements"""
+        from .response_handler import response_handler
+        from ..middleware import MiddlewareCapsule
+        from ..routes import Router
+        from ..loader import Loader
+
+        self.application.set_response_handler(response_handler)
+        self.application.use_storage_path(
+            os.path.join(self.application.base_path, "storage")
+        )
+        self.application.bind("middleware", MiddlewareCapsule())
+        self.application.bind(
+            "router",
+            Router(),
+        )
+        self.application.bind("loader", Loader())
+
+    def register_command_capsule(self) -> None:
+        """Register the 'commands' binding in the application."""
+        from cleo import Application as CommandApplication
+        from ..commands import CommandCapsule
+        from .. import __version__
+
+        self.application.bind(
+            "commands",
+            CommandCapsule(CommandApplication("Masonite", __version__))
+        )

--- a/src/masonite/foundation/Kernel.py
+++ b/src/masonite/foundation/Kernel.py
@@ -1,100 +1,65 @@
-import os
-from cleo import Application as CommandApplication
 from typing import TYPE_CHECKING
+
+from .CoreKernel import CoreKernel
 
 if TYPE_CHECKING:
     from .Application import Application
 
-from .response_handler import response_handler
-from .. import __version__
-from ..commands import (
-    TinkerCommand,
-    CommandCapsule,
-    KeyCommand,
-    ServeCommand,
-    QueueWorkCommand,
-    QueueRetryCommand,
-    QueueTableCommand,
-    QueueFailedCommand,
-    AuthCommand,
-    MakePolicyCommand,
-    MakeControllerCommand,
-    MakeJobCommand,
-    MakeMailableCommand,
-    MakeProviderCommand,
-    PublishPackageCommand,
-    MakeTestCommand,
-    DownCommand,
-    UpCommand,
-    MakeCommandCommand,
-    MakeViewCommand,
-    MakeMiddlewareCommand,
-    PresetCommand,
-)
-from ..environment import LoadEnvironment
-from ..middleware import MiddlewareCapsule
-from ..routes import Router
-from ..loader import Loader
 
-from ..tests.HttpTestResponse import HttpTestResponse
-from ..tests.TestResponseCapsule import TestResponseCapsule
-
-
-class Kernel:
+class Kernel(CoreKernel):
     def __init__(self, app: "Application"):
-        self.application = app
+        super().__init__(app)
 
     def register(self) -> None:
-        """Register core Masonite features in the project."""
-        self.load_environment()
-        self.register_framework()
+        """Register Additional Masonite features in the project"""
+        super().register()
         self.register_commands()
-        self.register_testing()
-
-    def load_environment(self) -> None:
-        """Load environment variables into the application."""
-        LoadEnvironment()
-
-    def register_framework(self) -> None:
-        self.application.set_response_handler(response_handler)
-        self.application.use_storage_path(
-            os.path.join(self.application.base_path, "storage")
-        )
-        self.application.bind("middleware", MiddlewareCapsule())
-        self.application.bind(
-            "router",
-            Router(),
-        )
-        self.application.bind("loader", Loader())
 
     def register_commands(self) -> None:
-        self.application.bind(
-            "commands",
-            CommandCapsule(CommandApplication("Masonite", __version__)).add(
-                TinkerCommand(),
-                KeyCommand(),
-                ServeCommand(self.application),
-                QueueWorkCommand(self.application),
-                QueueRetryCommand(self.application),
-                QueueFailedCommand(),
-                QueueTableCommand(),
-                AuthCommand(self.application),
-                MakePolicyCommand(self.application),
-                MakeControllerCommand(self.application),
-                MakeJobCommand(self.application),
-                MakeMailableCommand(self.application),
-                MakeProviderCommand(self.application),
-                PublishPackageCommand(self.application),
-                MakeTestCommand(self.application),
-                DownCommand(),
-                UpCommand(),
-                MakeCommandCommand(self.application),
-                MakeViewCommand(self.application),
-                MakeMiddlewareCommand(self.application),
-                PresetCommand(self.application),
-            ),
+        from ..commands import (
+            AuthCommand,
+            DownCommand,
+            KeyCommand,
+            MakeCommandCommand,
+            MakeControllerCommand,
+            MakeJobCommand,
+            MakeMailableCommand,
+            MakeMiddlewareCommand,
+            MakePolicyCommand,
+            MakeProviderCommand,
+            MakeTestCommand,
+            MakeViewCommand,
+            PresetCommand,
+            PublishPackageCommand,
+            QueueFailedCommand,
+            QueueRetryCommand,
+            QueueTableCommand,
+            QueueWorkCommand,
+            ServeCommand,
+            TinkerCommand,
+            UpCommand,
         )
 
-    def register_testing(self) -> None:
-        test_response = TestResponseCapsule(HttpTestResponse)
-        self.application.bind("tests.response", test_response)
+        self.application.make("commands").add(
+            AuthCommand(self.application),
+            DownCommand(),
+            KeyCommand(),
+            MakeCommandCommand(self.application),
+            MakeControllerCommand(self.application),
+            MakeJobCommand(self.application),
+            MakeMailableCommand(self.application),
+            MakeMiddlewareCommand(self.application),
+            MakePolicyCommand(self.application),
+            MakeProviderCommand(self.application),
+            MakeTestCommand(self.application),
+            MakeViewCommand(self.application),
+            PresetCommand(self.application),
+            PublishPackageCommand(self.application),
+            QueueFailedCommand(),
+            QueueRetryCommand(self.application),
+            QueueTableCommand(),
+            QueueWorkCommand(self.application),
+            ServeCommand(self.application),
+            TinkerCommand(),
+            UpCommand(),
+        )

--- a/src/masonite/foundation/Kernel.py
+++ b/src/masonite/foundation/Kernel.py
@@ -11,11 +11,11 @@ class Kernel(CoreKernel):
         super().__init__(app)
 
     def register(self) -> None:
-        """Register Additional Masonite features in the project"""
-        super().register()
+        """Register Initial Masonite features in the project"""
         self.register_commands()
 
     def register_commands(self) -> None:
+        """Add commands to the app"""
         from ..commands import (
             AuthCommand,
             DownCommand,

--- a/src/masonite/foundation/__init__.py
+++ b/src/masonite/foundation/__init__.py
@@ -1,1 +1,2 @@
 from .Application import Application
+from .response_handler import response_handler

--- a/src/masonite/foundation/__init__.py
+++ b/src/masonite/foundation/__init__.py
@@ -1,3 +1,1 @@
 from .Application import Application
-from .Kernel import Kernel
-from .response_handler import response_handler

--- a/tests/integrations/app/Kernel/Kernel.py
+++ b/tests/integrations/app/Kernel/Kernel.py
@@ -1,5 +1,5 @@
 from src.masonite.auth import Sign
-from src.masonite.foundation import response_handler
+from src.masonite.foundation.response_handler import response_handler
 from src.masonite.storage import StorageCapsule
 from src.masonite.environment import LoadEnvironment
 from src.masonite.configuration import Configuration, config
@@ -18,6 +18,8 @@ from src.masonite.routes import Route
 from src.masonite.utils.structures import load
 from src.masonite.utils.location import base_path
 
+from src.masonite.tests.HttpTestResponse import HttpTestResponse
+from src.masonite.tests.TestResponseCapsule import TestResponseCapsule
 
 class Kernel:
 
@@ -42,6 +44,7 @@ class Kernel:
 
     def register(self):
         self.load_environment()
+        self.register_testing()
         self.register_configurations()
         self.register_middleware()
         self.register_routes()
@@ -51,6 +54,11 @@ class Kernel:
 
     def load_environment(self):
         LoadEnvironment()
+
+    def register_testing(self) -> None:
+        test_response = TestResponseCapsule(HttpTestResponse)
+        self.application.bind("tests.response", test_response)
+
 
     def register_configurations(self):
         # load configuration

--- a/wsgi.py
+++ b/wsgi.py
@@ -1,4 +1,5 @@
-from src.masonite.foundation import Application, Kernel
+from src.masonite.foundation import Application
+from src.masonite.foundation.Kernel import Kernel
 from src.masonite.utils.location import base_path
 from tests.integrations.config.providers import PROVIDERS
 from tests.integrations.app.Kernel import Kernel as ApplicationKernel


### PR DESCRIPTION
> **Migrated from masoniteframework/masonite#860** (original author: @circulon) as part of the move to the `masonitedev` organization.
> Pending evaluation for inclusion in 5.x.

---

This PR updates the Kernel for the following:
- testing imports moved to the tests Kernel which means that pytest will no longer be a dependency of the main package
- added a "CoreKernel" for use when creating a custom root kernel to replace the internal `Kernel`
- lazy load all imports meaning that  `commands` etc are only imported is required and not as part of the `Kernel` module import

I can probably throw together some documentation for M5 around creating custom Kernels and the reason for doing so if required.

Note: this is a breaking change and the `Kernel` now needs to be imported explicitly  from the `foundation` module.
ie in the `wsgi.py` import it via `from masonite.foundation.Kernel import Kernel`
The `cookie-cutter` will need to be updated to reflect this change for new M5 installs

Note 2: this PR is failing tests but that is due to the testing against Python 3.8 which is no longer supported in M5.
 
