### PR TITLE
opt out using/adding commands

### DIFF
--- a/src/masonite/commands/CommandCapsule.py
+++ b/src/masonite/commands/CommandCapsule.py
@@ -10,9 +10,27 @@ class CommandCapsule:
         self.command_application = command_application
         self.commands = []
         self.command_name = []
+        self._enabled = True
+
+    def enable(self):
+        """
+        Allow command registration.
+        """
+        self._enabled = True
+
+    def disable(self):
+        """
+        Cleari all registered commands and preventing further command registration.
+        """
+        self._enabled = False
+        self.commands = []
+        self.command_name = []
 
     def add(self, *commands: "Command") -> "CommandCapsule":
         """Register new commands in the application."""
+        if not self._enabled:
+            return self
+
         for command in commands:
             command_name = command.config.name
             if command_name in self.command_name:
@@ -24,6 +42,9 @@ class CommandCapsule:
 
     def swap(self, command: "Command") -> None:
         """Swap an (existing) command with the given one."""
+        if not self._enabled:
+            return
+
         command_name = command.config.name
         # if command with same name has been registered remove it
         if self.command_application.find(command_name):

--- a/src/masonite/commands/CommandCapsule.py
+++ b/src/masonite/commands/CommandCapsule.py
@@ -6,29 +6,15 @@ if TYPE_CHECKING:
 
 
 class CommandCapsule:
-    def __init__(self, command_application: "CommandApplication"):
+    def __init__(self, command_application: "CommandApplication", enabled: bool = True):
         self.command_application = command_application
         self.commands = []
         self.command_name = []
-        self._enabled = True
-
-    def enable(self):
-        """
-        Allow command registration.
-        """
-        self._enabled = True
-
-    def disable(self):
-        """
-        Cleari all registered commands and preventing further command registration.
-        """
-        self._enabled = False
-        self.commands = []
-        self.command_name = []
+        self.enabled = enabled
 
     def add(self, *commands: "Command") -> "CommandCapsule":
         """Register new commands in the application."""
-        if not self._enabled:
+        if not self.enabled:
             return self
 
         for command in commands:
@@ -42,7 +28,7 @@ class CommandCapsule:
 
     def swap(self, command: "Command") -> None:
         """Swap an (existing) command with the given one."""
-        if not self._enabled:
+        if not self.enabled:
             return
 
         command_name = command.config.name

--- a/src/masonite/foundation/Application.py
+++ b/src/masonite/foundation/Application.py
@@ -14,11 +14,12 @@ ResponseHandler = Callable[[str, List[Tuple]], None]
 
 
 class Application(Container):
-    def __init__(self, base_path: str = None):
+    def __init__(self, base_path: str = None, commands_enabled: bool = True):
         self.base_path: str = base_path
         self.storage_path: str = None
         self.response_handler: ResponseHandler
         self.providers: list = []
+        self.commands_enabled = commands_enabled
 
     def set_response_handler(self, response_handler: ResponseHandler) -> None:
         self.response_handler = response_handler

--- a/src/masonite/foundation/Kernel.py
+++ b/src/masonite/foundation/Kernel.py
@@ -70,7 +70,10 @@ class Kernel:
     def register_commands(self) -> None:
         self.application.bind(
             "commands",
-            CommandCapsule(CommandApplication("Masonite", __version__)).add(
+            CommandCapsule(
+                CommandApplication("Masonite", __version__),
+                self.application.commands_enabled,
+            ).add(
                 TinkerCommand(),
                 KeyCommand(),
                 ServeCommand(self.application),


### PR DESCRIPTION
> **Migrated from masoniteframework/masonite#862** (original author: @circulon) as part of the move to the `masonitedev` organization.
> Pending evaluation for inclusion in 5.x.

---

on the back of #861 

This PR adds a flag to the Application init to enable addinf commands to the app.
The flag is `True` by default providing full compatibility with existing apps.

The `CommandCapsule` is still loaded so that Providers can still attempt to add commands duing their registration.

If the flag is set to `False` then no commands will added to the Capsule
