### PR TITLE
fix(structures): give data() a fresh dict per call

### DIFF
--- a/src/masonite/utils/structures.py
+++ b/src/masonite/utils/structures.py
@@ -47,7 +47,7 @@ def load(path, object_name=None, default=None, raise_exception=False):
                 return default
 
 
-def data(dictionary={}):
+def data(dictionary=None):
     """Transform the given dictionary to be read/written with dot notation.
 
     Arguments:
@@ -56,6 +56,11 @@ def data(dictionary={}):
     Returns:
         {dict} -- A dot dictionary
     """
+    # Use a fresh dict per call when none is given: a mutable default argument
+    # would be shared across every call, leaking keys between unrelated
+    # ``data()`` (and therefore ``Configuration``) instances.
+    if dictionary is None:
+        dictionary = {}
     return dotty(dictionary)
 
 

--- a/tests/core/utils/test_structures.py
+++ b/tests/core/utils/test_structures.py
@@ -42,3 +42,14 @@ class TestStructures(TestCase):
         dotted_struct["new_key.nested"] = 3
         self.assertEqual(dotted_struct.get("new_key.nested"), 3)
         self.assertEqual(dotted_struct, {"key": "val", "new_key": {"nested": 3}})
+
+    def test_data_without_argument_is_isolated(self):
+        # A mutable default argument would make every bare data() share one
+        # dict, leaking keys between unrelated callers (e.g. Configuration
+        # instances).
+        first = data()
+        first["leaked.key"] = "value"
+
+        second = data()
+        self.assertEqual(second, {})
+        self.assertIsNone(second.get("leaked.key"))


### PR DESCRIPTION
## Problem

`structures.data(dictionary={})` uses a **mutable default argument**. `dotty()` wraps the dict by reference, so every `data()` call made without an explicit dictionary shares the *same* dict object. Keys written through one bare `data()` leak into every later one — and since `Configuration.__init__` does `self._config = data()`, unrelated `Configuration` instances end up sharing state.

A single app has one `Configuration`, so it doesn't bite in production, but it breaks isolation anywhere multiple instances are created (surfaced while writing tests).

## Fix

Default `dictionary` to `None` and build a fresh `{}` per call. Behaviour is unchanged when an explicit dictionary is passed.

## Tests

Adds `test_data_without_argument_is_isolated` and keeps the existing structures tests green. Full suite verified locally on Python 3.10 and 3.13 (715 passed).