### PR TITLE
fix(validation): give MessageBag a fresh dict per instance

### DIFF
--- a/src/masonite/validation/MessageBag.py
+++ b/src/masonite/validation/MessageBag.py
@@ -4,7 +4,12 @@ import json
 
 
 class MessageBag:
-    def __init__(self, items={}):
+    def __init__(self, items=None):
+        # A mutable default would be shared across every MessageBag() created
+        # without explicit items, and add()/merge() mutate self.items in place —
+        # so errors would leak between unrelated bags. Build a fresh dict.
+        if items is None:
+            items = {}
         self.items = items
 
     def add(self, error, message):

--- a/tests/features/validation/test_messagebag.py
+++ b/tests/features/validation/test_messagebag.py
@@ -10,6 +10,16 @@ class TestMessageBag(unittest.TestCase):
         self.bag.add("email", "Your email is invalid")
         self.assertEqual(self.bag.items, {"email": ["Your email is invalid"]})
 
+    def test_separate_bags_do_not_share_state(self):
+        # A mutable default argument would make every MessageBag() share one
+        # dict, so errors added to one bag would leak into the next.
+        first = MessageBag()
+        first.add("email", "Your email is invalid")
+
+        second = MessageBag()
+        self.assertEqual(second.items, {})
+        self.assertFalse(second.any())
+
     def test_message_bag_can_add_several_errors_and_messages(self):
         self.bag.add("email", "Your email is invalid")
         self.bag.add("email", "Your email is invalid")


### PR DESCRIPTION
## Problem

`MessageBag(items={})` uses a **mutable default argument**, and `add()`/`merge()` mutate `self.items` in place. So any two `MessageBag()` created without explicit items share the *same* dict and leak errors into each other — the same footgun fixed for `data()` in #37.

This is currently **dormant**: every call site passes an explicit dictionary (`MessageBag(errors or {})`, `MessageBag(rule_errors)`, …), so nothing hits the default today. Fixing it pre-empts the bug for any future bare `MessageBag()`.

## Fix

Default `items` to `None` and build a fresh `{}` per instance.

## Tests

Adds `test_separate_bags_do_not_share_state` (fails on the old shared-default code). Full suite green locally on Python 3.10 and 3.13 (716 passed).