### PR TITLE
chore: point GitHub Sponsors funding at the masonitedev org

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,6 +1,6 @@
 # These are supported funding model platforms
 
-github: eaguad1337 # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
+github: masonitedev # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
 patreon: # Replace with a single Patreon username
 open_collective: # Replace with a single Open Collective username
 ko_fi: # Replace with a single Ko-fi username


### PR DESCRIPTION
Replaces the personal `eaguad1337` handle with the `masonitedev` org in the `github:` (GitHub Sponsors) field of `.github/FUNDING.yml`. Other platforms are left unchanged.