### PR TITLE
fix: defer Sign secret-key validation to point of use

### DIFF
--- a/src/masonite/auth/Sign.py
+++ b/src/masonite/auth/Sign.py
@@ -16,8 +16,10 @@ class Sign:
             key {string} -- The secret key to use. If nothing is passed it then it will use
                             the secret key from the config file. (default: {None})
 
-        Raises:
-            InvalidSecretKey -- Thrown if the secret key does not exist.
+        Note:
+            A missing key is not validated here. The check is deferred to
+            ``sign``/``unsign`` so the application can boot without a key set
+            (e.g. on a fresh install before ``craft key`` has been run).
         """
         if key:
             self.key = key
@@ -26,12 +28,18 @@ class Sign:
 
             self.key = application.make("key")
 
+        self.encryption = None
+
+    def _require_key(self):
+        """Ensure a secret key is present before signing or unsigning.
+
+        Raises:
+            InvalidSecretKey -- Thrown if the secret key does not exist.
+        """
         if not self.key:
             raise InvalidSecretKey(
                 "The encryption key passed in is: None. Be sure there is a secret key present in your .env file or your config/application.py file."
             )
-
-        self.encryption = None
 
     def sign(self, value):
         """Sign a value using the secret key.
@@ -43,8 +51,9 @@ class Sign:
             string -- Returns the encrypted value.
 
         Raises:
-            InvalidSecretKey -- Thrown if the secret key has incorrect padding.
+            InvalidSecretKey -- Thrown if the secret key is missing or has incorrect padding.
         """
+        self._require_key()
         try:
             f = Fernet(self.key)
         except (binascii.Error, ValueError):
@@ -65,7 +74,11 @@ class Sign:
 
         Returns:
             string -- Returns the unencrypted value.
+
+        Raises:
+            InvalidSecretKey -- Thrown if the secret key is missing.
         """
+        self._require_key()
         f = Fernet(self.key)
 
         if not value:

--- a/tests/core/authentication/test_email_verification.py
+++ b/tests/core/authentication/test_email_verification.py
@@ -4,7 +4,7 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 from src.masonite.auth import Sign, MustVerifyEmail
-from src.masonite.exceptions import InvalidToken
+from src.masonite.exceptions import InvalidSecretKey, InvalidToken
 from src.masonite.middleware import VerifiesEmailMiddleware
 
 # `src.masonite.auth` re-exports the MustVerifyEmail *class*, which shadows the
@@ -125,6 +125,27 @@ class TestSign(unittest.TestCase):
 
     def test_different_values_produce_different_tokens(self):
         self.assertNotEqual(self.sign.sign("1::1000"), self.sign.sign("2::1000"))
+
+    def test_missing_key_does_not_raise_on_construction(self):
+        # Regression: a fresh install boots with an empty APP_KEY; Sign must
+        # construct without raising so that `craft key` can run to generate one.
+        fake_app = MagicMock()
+        fake_app.make.return_value = ""
+        with patch.dict(sys.modules, {"wsgi": MagicMock(application=fake_app)}):
+            sign = Sign()  # no key passed -> resolves "" from the container
+        self.assertEqual(sign.key, "")
+
+    def test_sign_without_key_raises(self):
+        sign = Sign(key=TEST_KEY)
+        sign.key = ""
+        with self.assertRaises(InvalidSecretKey):
+            sign.sign("payload")
+
+    def test_unsign_without_key_raises(self):
+        sign = Sign(key=TEST_KEY)
+        sign.key = ""
+        with self.assertRaises(InvalidSecretKey):
+            sign.unsign("payload")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #43.

## Problem

A project with an empty `APP_KEY` cannot boot, but `craft key` — the command that generates the key — requires a full app boot to run. The one command meant to fix a missing key is blocked by the missing key.

The root cause is that `Sign.__init__` raises `InvalidSecretKey` when the key is falsy, and the skeleton Kernel constructs `Sign(key)` eagerly at boot (`bind("sign", Sign(key))`). The `__init__` guard is also redundant — `sign()`/`unsign()` already build `Fernet(self.key)`, which validates the key at the point of use.

## Change

- Move the missing-key check out of `Sign.__init__` into a small `_require_key()` helper.
- Call `_require_key()` at the start of `sign()` and `unsign()`.

Constructing `Sign` no longer raises, so the app boots with an empty key and `craft key` can generate one. The error still fires the moment anything actually signs or unsigns, so behavior for real usage is unchanged. This also fixes already-generated projects on upgrade, since they share the same skeleton Kernel.

## Tests

Extended `TestSign` in `tests/core/authentication/test_email_verification.py`:
- construction with a missing key does not raise
- `sign()` without a key raises `InvalidSecretKey`
- `unsign()` without a key raises `InvalidSecretKey`

Full non-integration suite passes locally (718 passed, 1 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)