### PR TITLE
feat: scaffold routes with explicit controller imports

### DIFF
--- a/src/masonite/skeleton/routes/api.py
+++ b/src/masonite/skeleton/routes/api.py
@@ -4,6 +4,8 @@ Routes defined here are registered under the "/api" prefix with the "api"
 middleware group when the ApiProvider is enabled in config/providers.py.
 """
 
+# from app.controllers.UsersController import UsersController
+
 ROUTES = [
-    # Route.get("/users", "UsersController@index"),
+    # Route.get("/users", UsersController.index),
 ]

--- a/src/masonite/skeleton/routes/web.py
+++ b/src/masonite/skeleton/routes/web.py
@@ -1,5 +1,7 @@
 from masonite.routes import Route
 
+from app.controllers.WelcomeController import WelcomeController
+
 ROUTES = [
-    Route.get("/", "WelcomeController@show").name("welcome"),
+    Route.get("/", WelcomeController.show).name("welcome"),
 ]


### PR DESCRIPTION
## Context

Comes out of discussion #42: the default `routes/web.py` uses the string syntax `"WelcomeController@show"`, and adopting an explicit controller-import style was proposed.

## Finding

This syntax is **already supported by the framework** — no core changes are required. `HTTPRoute._find_controller` (`src/masonite/routes/HTTPRoute.py:187-202`) already resolves a `Class.method` reference passed directly via `__qualname__`/`__module__`. It is in fact the same mechanism `Route.view`/`Route.redirect` use internally (`ViewController.show`, `RedirectController.redirect`).

So this PR is a **scaffold-only, non-breaking change**.

## Change

Updates the skeleton route files to import the controller class and pass the method directly:

```python
from masonite.routes import Route

from app.controllers.WelcomeController import WelcomeController

ROUTES = [
    Route.get("/", WelcomeController.show).name("welcome"),
]
```

(The commented example in `api.py` is updated to match.)

## Why

- Enables go-to-definition, autocomplete and rename refactors in the IDE.
- Typos / missing controllers fail at import time instead of at runtime with a warning + `SyntaxError` when the request hits the route.
- Removes the "magic" string resolution via `controllers_locations`.

## Compatibility

- The string `"Controller@method"` form **remains fully supported**; existing apps are unaffected.
- The `Route.resource()` / `Route.api()` helpers still take a string controller. Standardizing those to the class style would be a separate follow-up (the only point of inconsistency with this convention).

Closes #42.