### PR TITLE
fix(deps): bump axios to ^0.32.0 (GHSA-3g43-6gmg-66jw)

### DIFF
--- a/src/masonite/stubs/presets/base/package.json
+++ b/src/masonite/stubs/presets/base/package.json
@@ -10,7 +10,7 @@
     "production": "mix --production"
   },
   "devDependencies": {
-    "axios": "^0.22.0",
+    "axios": "^0.32.0",
     "laravel-mix": "^6.0.39",
     "postcss": "^8.4.5"
   }


### PR DESCRIPTION
## What
Bumps `axios` from `^0.22.0` to `^0.32.0` in `src/masonite/stubs/presets/base/package.json`.

## Why
Resolves Dependabot high-severity alert #1: **axios Vulnerable to Credential Theft and Response Hijacking via Prototype Pollution Gadget in Config Merge** ([GHSA-3g43-6gmg-66jw](https://github.com/axios/axios/security/advisories/GHSA-3g43-6gmg-66jw)).

- Vulnerable range (0.x line): `>= 0.19.0, < 0.31.1`
- `^0.22.0` was affected; `^0.32.0` is patched.

Stays on the 0.x line to avoid a major-version jump on this maintenance branch's laravel-mix toolchain (the `5.0` branch already moved to axios 1.x with Vite).