### PR TITLE
Feature: merge multiple config paths

### DIFF
--- a/src/masonite/configuration/Configuration.py
+++ b/src/masonite/configuration/Configuration.py
@@ -3,6 +3,34 @@ from ..utils.structures import data
 from ..exceptions import InvalidConfigurationLocation, InvalidConfigurationSetup
 
 
+def _deep_merge(base, override):
+    """
+    Recursively merge override into base, preserving the base type.
+
+    - dicts: recursively merge matching keys; override wins on conflicts
+    - lists: concatenate with override preference deduplication —
+             base entries already present in override are dropped,
+             then override is appended in full
+    - scalars: override wins
+
+    Arguments:
+        base -- the existing value to merge into
+        override -- the incoming value to merge from
+
+    Returns:
+        merged value of the same type as base, or override if types differ
+    """
+    if isinstance(base, list) and isinstance(override, list):
+        return [v for v in base if v not in override] + override
+    if isinstance(base, dict) and isinstance(override, dict):
+        result = dict(base)
+        for key, override_value in override.items():
+            base_value = result.get(key)
+            result[key] = _deep_merge(base_value, override_value) if base_value is not None else override_value
+        return result
+    return override
+
+
 class Configuration:
     # Foundation configuration keys
     reserved_keys = [
@@ -23,20 +51,45 @@ class Configuration:
         self.application = application
         self._config = data()
 
-    def load(self):
-        """At boot load configuration from all files and store them in here."""
-        config_root = self.application.make("config.location")
-        for module_name, module in Loader.get_modules(
-            config_root, raise_exception=True
-        ).items():
-            params = Loader.get_parameters(module)
-            for name, value in params.items():
-                self._config[f"{module_name}.{name.lower()}"] = value
+    def load(self, other_paths: list[str] = None):
+        """
+        Load configuration from files, deep-merging each location into the
+        accumulated config in order. The base location is loaded first,
+        followed by each additional location in the order provided.
 
-        # check loaded configuration
+        Overlay locations are partial by design — they only need to contain
+        the modules they wish to add or override. Missing modules in an
+        overlay are silently skipped. New modules introduced by an overlay
+        are added to the config as-is.
+
+        Arguments:
+            other_paths {list[str]|None} -- explicit overlay locations to load after the base;
+                                          each is a dot-separated module path (e.g. "environment.prod")
+
+        Raises:
+            InvalidConfigurationLocation -- if no application config is present after all
+                                            locations have been loaded, indicating the base
+                                            location is missing or incorrect
+        """
+        base_location = self.application.make("config.location")
+        config_roots = [base_location]
+        config_roots.extend(other_paths or [])
+
+        for config_root in config_roots:
+            for module_name, module in Loader.get_modules(
+                    config_root, raise_exception=False
+            ).items():
+                params = Loader.get_parameters(module)
+                incoming = {name.lower(): value for name, value in params.items()}
+                existing = self._config.get(module_name)
+                if existing is not None:
+                    self._config[module_name] = _deep_merge(existing, incoming)
+                else:
+                    self._config[module_name] = incoming
+
         if not self._config.get("application"):
             raise InvalidConfigurationLocation(
-                f"Config directory {config_root} does not contain required configuration files."
+                f"Config directory '{base_location}' does not contain required configuration files."
             )
 
     def merge_with(self, path, external_config):

--- a/src/masonite/tests/TestCase.py
+++ b/src/masonite/tests/TestCase.py
@@ -50,6 +50,7 @@ class TestCase(unittest.TestCase):
         self.application: "Application" = application
         self.original_class_mocks = {}
 
+        self._original_config_location = application.make("config.location")
         self._acting_as = {}
         self._test_cookies = {}
         self._test_headers = {}
@@ -85,6 +86,7 @@ class TestCase(unittest.TestCase):
         """Define code that should be run after each unit tests."""
         self.withoutCsrf()
         self.withoutExceptionsHandling()
+        self.application.bind("config.location", self._original_config_location)
         self._acting_as = {}
         self._test_cookies = {}
         self._test_session = {}

--- a/tests/core/configuration_loader/conftest.py
+++ b/tests/core/configuration_loader/conftest.py
@@ -1,0 +1,14 @@
+"""Test database bootstrap.
+
+The test database is no longer committed to the repository. Instead it is
+built fresh from the test migrations and seeds at the start of every test
+session, so the suite always starts from a known, clean state and nothing has
+to be restored afterwards.
+"""
+
+import pytest
+
+@pytest.fixture(scope="module", autouse=True)
+def build_test_database():
+    """override the default session builder"""
+    yield

--- a/tests/core/configuration_loader/test_config_loader.py
+++ b/tests/core/configuration_loader/test_config_loader.py
@@ -1,0 +1,41 @@
+import unittest
+
+from src.masonite.configuration import Configuration
+from src.masonite.foundation.Application import Application
+from src.masonite.utils.location import base_path
+from src.masonite.foundation.CoreKernel import CoreKernel
+
+class TestConfigLoader(unittest.TestCase):
+
+    def setUp(self):
+        custom_application = Application(base_path("tests/integrations"), False)
+        custom_application.register_providers(CoreKernel)
+        self.application = custom_application
+
+    def tearDown(self):
+        self.application = None  # already done — good
+
+    def test_load_ignores_config_subfolders(self):
+        self.application.bind("config.location", "tests/integrations/config")
+        configuration = Configuration(self.application)
+        configuration.load()
+
+        self.assertEqual(len(configuration._config.keys()), 17)
+
+    def test_can_merge_configs_from_other_paths(self):
+        config_root = "tests/integrations/config"
+        self.application.bind("config.location", f"{config_root}")
+        configuration = Configuration(self.application)
+        configuration.load([
+            "tests.integrations.config.base",
+            "tests.integrations.config.environment.prod",
+            f"{config_root}/deployed",
+        ])
+
+        self.assertEqual(len(configuration._config.keys()), 18)
+        config = configuration.all()
+        self.assertEqual(config["database"]["databases"]["default"], "postgres")
+        self.assertEqual(config["database"]["databases"]["postgres"]["driver"], "postgres")
+        self.assertEqual(config["database"]["databases"]["postgres"]["password"], "deployed_password")
+        self.assertEqual(config["cache"]["stores"]["redis"]["host"], "deployed.host.org")
+        self.assertEqual(config["external"]["services"]["stripe"]["api_key"], "not set")

--- a/tests/integrations/config/base/application.py
+++ b/tests/integrations/config/base/application.py
@@ -1,0 +1,2 @@
+KEY = "base_key"
+DEBUG = False

--- a/tests/integrations/config/base/cache.py
+++ b/tests/integrations/config/base/cache.py
@@ -1,0 +1,9 @@
+"""Cache Config"""
+
+STORES = {
+    "default": "redis",
+    "redis": {
+        "driver": "redis",
+        "port": "6379",
+    },
+}

--- a/tests/integrations/config/base/database.py
+++ b/tests/integrations/config/base/database.py
@@ -1,0 +1,7 @@
+DATABASES = {
+    "default": "sqlite",
+    "sqlite": {
+        "driver": "sqlite",
+        "database": "base_database.sqlite3",
+    },
+}

--- a/tests/integrations/config/base/external.py
+++ b/tests/integrations/config/base/external.py
@@ -1,0 +1,11 @@
+SERVICES = {
+    "amazon": {
+        "api_key": "not set",
+    },
+    "stripe": {
+        "api_key": "not set",
+    },
+    "claude": {
+        "api_key": "not set",
+    },
+}

--- a/tests/integrations/config/deployed/cache.py
+++ b/tests/integrations/config/deployed/cache.py
@@ -1,0 +1,8 @@
+"""Cache Config"""
+
+STORES = {
+    "redis": {
+        "host": "deployed.host.org",
+        "password": "my_redis_password",
+    },
+}

--- a/tests/integrations/config/deployed/database.py
+++ b/tests/integrations/config/deployed/database.py
@@ -1,0 +1,6 @@
+DATABASES = {
+    "postgres": {
+        "user": "editor_user",
+        "password": "deployed_password",
+    },
+}

--- a/tests/integrations/config/environment/dev/application.py
+++ b/tests/integrations/config/environment/dev/application.py
@@ -1,0 +1,2 @@
+KEY = "local_key
+DEBUG = True

--- a/tests/integrations/config/environment/local/application.py
+++ b/tests/integrations/config/environment/local/application.py
@@ -1,0 +1,2 @@
+KEY = "local_key"
+DEBUG = True

--- a/tests/integrations/config/environment/local/cache.py
+++ b/tests/integrations/config/environment/local/cache.py
@@ -1,0 +1,9 @@
+"""Cache Config"""
+
+STORES = {
+    "default": "local",
+    "local": {
+        "driver": "file",
+        "location": "local/storage/framework/cache"
+    },
+}

--- a/tests/integrations/config/environment/local/database.py
+++ b/tests/integrations/config/environment/local/database.py
@@ -1,0 +1,7 @@
+from masoniteorm.connections import ConnectionResolver
+
+DATABASES = {
+    "sqlite": {
+        "database": "local_database.sqlite3",
+    },
+}

--- a/tests/integrations/config/environment/prod/application.py
+++ b/tests/integrations/config/environment/prod/application.py
@@ -1,0 +1,3 @@
+KEY = "prod_key"
+
+DEBUG = False

--- a/tests/integrations/config/environment/prod/cache.py
+++ b/tests/integrations/config/environment/prod/cache.py
@@ -1,0 +1,6 @@
+"""Cache Config"""
+
+STORES = {
+    "redis": {
+        "name": "prod_cache",    },
+}

--- a/tests/integrations/config/environment/prod/database.py
+++ b/tests/integrations/config/environment/prod/database.py
@@ -1,0 +1,7 @@
+DATABASES = {
+    "default": "postgres",
+    "postgres": {
+        "driver": "postgres",
+        "database": "production",
+    },
+}


### PR DESCRIPTION
This PR provides the ability to "stack" config as a hierarchy.

The reason being that not all environments should contain every customisation in environmet vars.
This provides the ability to override specific keys in dicts and append items to lists in the config in a very simple and obvious way.

example loader:
```python
self.application.bind("config.location", "config.base")
configuration = Configuration(self.application)
configuration.load([
    "config.environment.prod",
    "config/deployed",
])  
```
this will load and update the config in the following order from lowest to highest priority:
- config.base
- config.environment.prod
- config.deployed
