### PR TITLE
Fix add_query_params dropping port and userinfo from URLs

### DIFF
--- a/src/masonite/utils/str.py
+++ b/src/masonite/utils/str.py
@@ -81,8 +81,11 @@ def add_query_params(url: str, query_params: dict) -> str:
     """Add query params dict to a given url (which can already contain some query parameters)."""
     path_result = parse.urlsplit(url)
 
+    # Use netloc (not hostname) so a non-default port and any userinfo are
+    # preserved: hostname drops them, turning e.g. http://host:9000 into
+    # http://host and breaking redirects to URLs with explicit ports.
     base_url = (
-        f"{path_result.scheme}://{path_result.hostname}" if path_result.hostname else ""
+        f"{path_result.scheme}://{path_result.netloc}" if path_result.netloc else ""
     )
     base_path = path_result.path
 

--- a/tests/core/utils/test_str.py
+++ b/tests/core/utils/test_str.py
@@ -42,10 +42,26 @@ class TestStringsUtils(TestCase):
             "https://example.com/c/pay/cs_teAIXs#fid2cGd2ZndsdXFsamtQa2x0cGBrYHZ2QGtkZ2lgYSc%2FY2RpdmApJ2R1bE5gfCc%2FJ3VuWnFgdnFac2FiQF9fbWppSTxkc01tcWRTMzA9fVdgNTVHfXJWcGhUPCcpJ2N3amhWYHdzYHcnP3F3cGApJ2lkfGpwcVF8dWAnPyd2bGtiaWBabHFgaCcpJ2BrZGdpYFVpZGZgbWppYWB3dic%2FcXdwYHgl",
             "https://example.com?a=b",
             "https://example.com/",
+            # a non-default port must survive an empty add (e.g. presigned S3/MinIO URLs)
+            "http://127.0.0.1:9000/bucket/key?X-Amz-Signature=abc",
+            # userinfo must survive too
+            "http://user:pass@example.com:8080/path?a=b",
         ]
 
         for url in test_urls:
             self.assertEqual(url, add_query_params(url, {}))
+
+    def test_add_query_params_preserves_port_and_userinfo(self):
+        # Regression: the URL was rebuilt from `hostname`, dropping the port and
+        # userinfo (so http://host:9000 became http://host).
+        self.assertEqual(
+            "http://127.0.0.1:9000/bucket/key?a=b",
+            add_query_params("http://127.0.0.1:9000/bucket/key", {"a": "b"}),
+        )
+        self.assertEqual(
+            "http://user:pass@example.com:8080/path",
+            add_query_params("http://user:pass@example.com:8080/path", {}),
+        )
 
     def test_add_query_params_add_params(self):
         test_urls = [


### PR DESCRIPTION
## Problem

`masonite.utils.str.add_query_params` rebuilds the base URL from `urlsplit(url).hostname`, which **excludes the port and any userinfo**. So any URL with a non-default port loses it:

```python
add_query_params("http://127.0.0.1:9000/bucket/key", {})
# -> "http://127.0.0.1/bucket/key"   (the :9000 is gone)
```

Because `Response.redirect(location=...)` passes the location through `add_query_params`, redirecting to a URL on a non-default port produces a broken `Location` header. I hit this redirecting to a **presigned S3/MinIO URL** (`http://host:9000/...?X-Amz-Signature=...`): the port was stripped, so the browser hit port 80 and the download failed.

## Fix

Use `urlsplit(url).netloc` instead of `.hostname`. `netloc` preserves host, port, and userinfo — `hostname` drops the port and userinfo. One line in `src/masonite/utils/str.py`.

## Tests

Added to `tests/core/utils/test_str.py`:
- non-default port and userinfo URLs are unchanged by an empty `add_query_params(url, {})`
- a regression test asserting the port survives when params are added, and userinfo is preserved

Existing `add_query_params` test expectations are unaffected (verified).